### PR TITLE
fix correct api format for purging cdn endpoint

### DIFF
--- a/src/lib/services/cdn-service.ts
+++ b/src/lib/services/cdn-service.ts
@@ -148,7 +148,7 @@ export class CdnService {
    */
   public purgeEndpointCache(id: string, files: string[]): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/cdn/endpoints/${id}`, { data: { files } })
+      Axios.delete(`${API_BASE_URL}/cdn/endpoints/${id}`, { files })
         .then(() => {
           resolve();
         })


### PR DESCRIPTION
The API accepts a "files" array parameter , not a "data" object and then the "files" array within that.

* **What kind of change does this PR introduce?** **Bug Fix**
https://github.com/johnbwoodruff/digitalocean-js/issues/23


* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/johnbwoodruff/digitalocean-js/issues/23


* **What is the new behavior (if this is a feature change)?**



* **Other information**:
