### PR TITLE
Make base API URL configurable

### DIFF
--- a/src/lib/digitalocean.ts
+++ b/src/lib/digitalocean.ts
@@ -1,4 +1,5 @@
 import Axios from 'axios';
+import { API_BASE_URL } from './conf/environment';
 import { AccountService } from './services/account-service';
 import { ActionService } from './services/actions-service';
 import { BlockStorageActionService } from './services/block-storage-actions-service';
@@ -48,9 +49,10 @@ export class DigitalOcean {
   public ssh: SshService;
   public tags: TagService;
 
-  constructor(private token: string) {
+  constructor(private token: string, url = API_BASE_URL) {
     Axios.defaults.headers.common.Authorization = `Bearer ${this.token}`;
     Axios.defaults.headers.common['Content-Type'] = `application/json`;
+    Axios.defaults.baseURL = url;
 
     this.account = new AccountService();
     this.actions = new ActionService();

--- a/src/lib/services/account-service.ts
+++ b/src/lib/services/account-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Account } from '../models/account';
 
 export class AccountService {
@@ -19,7 +18,7 @@ export class AccountService {
    */
   public getUserInformation(): Promise<Account> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/account`)
+      Axios.get(`/account`)
         .then(response => {
           // Return actual account instead of wrapped account
           resolve(response.data.account);

--- a/src/lib/services/actions-service.ts
+++ b/src/lib/services/actions-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Action } from '../models/action';
 
 export class ActionService {
@@ -24,7 +23,7 @@ export class ActionService {
     page = page ? page : 1;
     perPage = perPage ? perPage : 25;
     return new Promise((resolve, reject) => {
-      let url = `${API_BASE_URL}/actions`;
+      let url = `/actions`;
       url += `?page=${page}`;
       url += `&per_page=${perPage}`;
       Axios.get(url)
@@ -51,7 +50,7 @@ export class ActionService {
    */
   public getExistingAction(id: number): Promise<Action> {
     return new Promise((resolve, reject) => {
-      const url = `${API_BASE_URL}/actions/${id}`;
+      const url = `/actions/${id}`;
       Axios.get(url)
         .then(response => {
           // Return actual action instead of wrapped action

--- a/src/lib/services/block-storage-actions-service.ts
+++ b/src/lib/services/block-storage-actions-service.ts
@@ -1,5 +1,5 @@
 import Axios from 'axios';
-import { API_BASE_URL } from '../conf/environment';
+
 import { Action, ActionRequest } from '../models/action';
 
 export class BlockStorageActionService {
@@ -30,7 +30,7 @@ export class BlockStorageActionService {
       if (!this.attachActionIsValid(actionRequest)) {
         throw new Error('Required fields missing from Action Object');
       }
-      Axios.post(`${API_BASE_URL}/volumes/${volumeId}/actions`, actionRequest)
+      Axios.post(`/volumes/${volumeId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -66,7 +66,7 @@ export class BlockStorageActionService {
       if (!this.attachActionByNameIsValid(actionRequest)) {
         throw new Error('Required fields missing from Action Object');
       }
-      Axios.post(`${API_BASE_URL}/volumes/actions`, actionRequest)
+      Axios.post(`/volumes/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -102,7 +102,7 @@ export class BlockStorageActionService {
       if (!this.attachActionIsValid(actionRequest)) {
         throw new Error('Required fields missing from Action Object');
       }
-      Axios.post(`${API_BASE_URL}/volumes/${volumeId}/actions`, actionRequest)
+      Axios.post(`/volumes/${volumeId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -138,7 +138,7 @@ export class BlockStorageActionService {
       if (!this.attachActionByNameIsValid(actionRequest)) {
         throw new Error('Required fields missing from Action Object');
       }
-      Axios.post(`${API_BASE_URL}/volumes/actions`, actionRequest)
+      Axios.post(`/volumes/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -174,7 +174,7 @@ export class BlockStorageActionService {
       if (!this.resizeActionIsValid(actionRequest)) {
         throw new Error('Required fields missing from Action Object');
       }
-      Axios.post(`${API_BASE_URL}/volumes/${volumeId}/actions`, actionRequest)
+      Axios.post(`/volumes/${volumeId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -208,7 +208,7 @@ export class BlockStorageActionService {
     page = page ? page : 1;
     perPage = perPage ? perPage : 25;
     return new Promise((resolve, reject) => {
-      let url = `${API_BASE_URL}/volumes/${volumeId}/actions`;
+      let url = `/volumes/${volumeId}/actions`;
       url += `?page=${page}`;
       url += `&per_page=${perPage}`;
       Axios.get(url)
@@ -239,7 +239,7 @@ export class BlockStorageActionService {
     actionId: number
   ): Promise<Action> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/volumes/${volumeId}/actions/${actionId}`)
+      Axios.get(`/volumes/${volumeId}/actions/${actionId}`)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);

--- a/src/lib/services/block-storage-service.ts
+++ b/src/lib/services/block-storage-service.ts
@@ -1,5 +1,5 @@
 import Axios from 'axios';
-import { API_BASE_URL } from '../conf/environment';
+
 import { BlockStorage, BlockStorageRequest } from '../models/block-storage';
 import { Snapshot } from '../models/snapshot';
 
@@ -19,7 +19,7 @@ export class BlockStorageService {
    */
   public getAllBlockStorage(): Promise<BlockStorage[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/volumes`)
+      Axios.get(`/volumes`)
         .then(response => {
           // Return actual volumes instead of wrapped volumes
           resolve(response.data.volumes);
@@ -54,7 +54,7 @@ export class BlockStorageService {
       if (!this.volumeIsValid(volume)) {
         throw new Error('Required fields missing from Block Storage Object');
       }
-      Axios.post(`${API_BASE_URL}/volumes`, volume)
+      Axios.post(`/volumes`, volume)
         .then(response => {
           // Return actual volume instead of wrapped volume
           resolve(response.data.volume);
@@ -78,7 +78,7 @@ export class BlockStorageService {
    */
   public getBlockStorageById(id: string): Promise<BlockStorage> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/volumes/${id}`)
+      Axios.get(`/volumes/${id}`)
         .then(response => {
           // Return actual volume instead of wrapped volume
           resolve(response.data.volume);
@@ -106,7 +106,7 @@ export class BlockStorageService {
     regionSlug: string
   ): Promise<BlockStorage[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/volumes?name=${name}&region=${regionSlug}`)
+      Axios.get(`/volumes?name=${name}&region=${regionSlug}`)
         .then(response => {
           // Return actual volumes instead of wrapped volumes
           resolve(response.data.volumes);
@@ -131,7 +131,7 @@ export class BlockStorageService {
    */
   public getSnapshotsForVolume(id: string): Promise<Snapshot[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/volumes/${id}/snapshots`)
+      Axios.get(`/volumes/${id}/snapshots`)
         .then(response => {
           // Return actual snapshots instead of wrapped snapshots
           resolve(response.data.snapshots);
@@ -156,7 +156,7 @@ export class BlockStorageService {
    */
   public createSnapshotFromVolume(id: string, name: string): Promise<Snapshot> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/volumes/${id}/snapshots`, { name })
+      Axios.post(`/volumes/${id}/snapshots`, { name })
         .then(response => {
           // Return actual snapshot instead of wrapped snapshot
           resolve(response.data.snapshot);
@@ -180,7 +180,7 @@ export class BlockStorageService {
    */
   public deleteBlockStorageById(id: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/volumes/${id}`)
+      Axios.delete(`/volumes/${id}`)
         .then(() => {
           resolve();
         })
@@ -206,7 +206,7 @@ export class BlockStorageService {
     regionSlug: string
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/volumes?name=${name}&region=${regionSlug}`)
+      Axios.delete(`/volumes?name=${name}&region=${regionSlug}`)
         .then(() => {
           resolve();
         })

--- a/src/lib/services/cdn-service.ts
+++ b/src/lib/services/cdn-service.ts
@@ -1,5 +1,5 @@
 import Axios from 'axios';
-import { API_BASE_URL } from '../conf/environment';
+
 import { CdnEndpoint, CdnEndpointRequest } from '../models/cdn';
 
 export class CdnService {
@@ -18,7 +18,7 @@ export class CdnService {
    */
   public getAllEndpoints(): Promise<CdnEndpoint[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/cdn/endpoints`)
+      Axios.get(`/cdn/endpoints`)
         .then(response => {
           // Return actual endpoints instead of wrapped endpoints
           resolve(response.data.endpoints);
@@ -42,7 +42,7 @@ export class CdnService {
    */
   public getExistingEndpoint(id: string): Promise<CdnEndpoint> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/cdn/endpoints/${id}`)
+      Axios.get(`/cdn/endpoints/${id}`)
         .then(response => {
           // Return actual endpoint instead of wrapped endpoint
           resolve(response.data.endpoint);
@@ -73,7 +73,7 @@ export class CdnService {
       if (!this.endpointIsValid(endpoint)) {
         throw new Error('Required fields missing from Endpoint Object');
       }
-      Axios.post(`${API_BASE_URL}/cdn/endpoints`, endpoint)
+      Axios.post(`/cdn/endpoints`, endpoint)
         .then(response => {
           // Return actual endpoint instead of wrapped endpoint
           resolve(response.data.endpoint);
@@ -97,7 +97,7 @@ export class CdnService {
    */
   public updateEndpoint(id: string, ttl: number): Promise<CdnEndpoint> {
     return new Promise((resolve, reject) => {
-      Axios.put(`${API_BASE_URL}/cdn/endpoints/${id}`, { ttl })
+      Axios.put(`/cdn/endpoints/${id}`, { ttl })
         .then(response => {
           // Return actual endpoint instead of wrapped endpoint
           resolve(response.data.endpoint);
@@ -121,7 +121,7 @@ export class CdnService {
    */
   public deleteEndpoint(id: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/cdn/endpoints/${id}`)
+      Axios.delete(`/cdn/endpoints/${id}`)
         .then(() => {
           resolve();
         })
@@ -148,7 +148,7 @@ export class CdnService {
    */
   public purgeEndpointCache(id: string, files: string[]): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/cdn/endpoints/${id}/cache`, {
+      Axios.delete(`/cdn/endpoints/${id}/cache`, {
         data: { files }
       })
         .then(() => {

--- a/src/lib/services/certificate-service.ts
+++ b/src/lib/services/certificate-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Certificate, CertificateRequest } from '../models/certificate';
 
 export class CertificateService {
@@ -27,7 +26,7 @@ export class CertificateService {
     certificateRequest: CertificateRequest
   ): Promise<Certificate> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/certificates`, certificateRequest)
+      Axios.post(`/certificates`, certificateRequest)
         .then(response => {
           // Return actual certificate instead of wrapped certificate
           resolve(response.data.certificate);
@@ -51,7 +50,7 @@ export class CertificateService {
    */
   public getExistingCertificate(certificateId: string): Promise<Certificate> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/certificates/${certificateId}`)
+      Axios.get(`/certificates/${certificateId}`)
         .then(response => {
           // Return actual certificate instead of wrapped certificate
           resolve(response.data.certificate);
@@ -75,7 +74,7 @@ export class CertificateService {
    */
   public getAllCertificates(): Promise<Certificate[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/certificates`)
+      Axios.get(`/certificates`)
         .then(response => {
           // Return actual certificates instead of wrapped certificates
           resolve(response.data.certificates);
@@ -99,7 +98,7 @@ export class CertificateService {
    */
   public deleteCertificate(certificateId: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/certificates/${certificateId}`)
+      Axios.delete(`/certificates/${certificateId}`)
         .then(() => {
           resolve();
         })

--- a/src/lib/services/domain-record-service.ts
+++ b/src/lib/services/domain-record-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { DomainRecord, DomainRecordRequest } from '../models/domain-record';
 
 export class DomainRecordService {
@@ -19,7 +18,7 @@ export class DomainRecordService {
    */
   public getAllDomainRecords(domainName: string): Promise<DomainRecord[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/domains/${domainName}/records`)
+      Axios.get(`/domains/${domainName}/records`)
         .then(response => {
           // Return actual domain_records instead of wrapped domain_records
           resolve(response.data.domain_records);
@@ -58,7 +57,7 @@ export class DomainRecordService {
     domainRequest: DomainRecordRequest
   ): Promise<DomainRecord> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/domains/${domainName}/records`, domainRequest)
+      Axios.post(`/domains/${domainName}/records`, domainRequest)
         .then(response => {
           // Return actual domain_record instead of wrapped domain_record
           resolve(response.data.domain_record);
@@ -86,7 +85,7 @@ export class DomainRecordService {
     recordId: number
   ): Promise<DomainRecord> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/domains/${domainName}/records/${recordId}`)
+      Axios.get(`/domains/${domainName}/records/${recordId}`)
         .then(response => {
           // Return actual domain_record instead of wrapped domain_record
           resolve(response.data.domain_record);
@@ -119,10 +118,7 @@ export class DomainRecordService {
     domainRequest: DomainRecordRequest
   ): Promise<DomainRecord> {
     return new Promise((resolve, reject) => {
-      Axios.put(
-        `${API_BASE_URL}/domains/${domainName}/records/${recordId}`,
-        domainRequest
-      )
+      Axios.put(`/domains/${domainName}/records/${recordId}`, domainRequest)
         .then(response => {
           // Return actual domain_record instead of wrapped domain_record
           resolve(response.data.domain_record);
@@ -149,7 +145,7 @@ export class DomainRecordService {
     recordId: number
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/domains/${domainName}/records/${recordId}`)
+      Axios.delete(`/domains/${domainName}/records/${recordId}`)
         .then(() => {
           // Return actual domain_record instead of wrapped domain_record
           resolve();

--- a/src/lib/services/domain-service.ts
+++ b/src/lib/services/domain-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Domain, DomainRequest } from '../models/domain';
 
 export class DomainService {
@@ -19,7 +18,7 @@ export class DomainService {
    */
   public getAllDomains(): Promise<Domain[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/domains`)
+      Axios.get(`/domains`)
         .then(response => {
           // Return actual domains instead of wrapped domains
           resolve(response.data.domains);
@@ -47,7 +46,7 @@ export class DomainService {
    */
   public createDomain(domainRequest: DomainRequest): Promise<Domain> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/domains`, domainRequest)
+      Axios.post(`/domains`, domainRequest)
         .then(response => {
           // Return actual domain instead of wrapped domain
           resolve(response.data.domain);
@@ -71,7 +70,7 @@ export class DomainService {
    */
   public getExistingDomain(domainName: string): Promise<Domain> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/domains/${domainName}`)
+      Axios.get(`/domains/${domainName}`)
         .then(response => {
           // Return actual domain instead of wrapped domain
           resolve(response.data.domain);
@@ -95,7 +94,7 @@ export class DomainService {
    */
   public deleteDomain(domainName: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/domains/${domainName}`)
+      Axios.delete(`/domains/${domainName}`)
         .then(() => {
           resolve();
         })

--- a/src/lib/services/droplet-actions-service.ts
+++ b/src/lib/services/droplet-actions-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Action } from '../models/action';
 import { DropletActionRequest } from '../models/droplet';
 
@@ -23,7 +22,7 @@ export class DropletActionService {
       const actionRequest: DropletActionRequest = {
         type: 'enable_backups'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -50,7 +49,7 @@ export class DropletActionService {
       const actionRequest: DropletActionRequest = {
         type: 'disable_backups'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -77,7 +76,7 @@ export class DropletActionService {
       const actionRequest: DropletActionRequest = {
         type: 'reboot'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -104,7 +103,7 @@ export class DropletActionService {
       const actionRequest: DropletActionRequest = {
         type: 'power_cycle'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -131,7 +130,7 @@ export class DropletActionService {
       const actionRequest: DropletActionRequest = {
         type: 'shutdown'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -158,7 +157,7 @@ export class DropletActionService {
       const actionRequest: DropletActionRequest = {
         type: 'power_off'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -185,7 +184,7 @@ export class DropletActionService {
       const actionRequest: DropletActionRequest = {
         type: 'power_on'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -216,7 +215,7 @@ export class DropletActionService {
         image,
         type: 'restore'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -243,7 +242,7 @@ export class DropletActionService {
       const actionRequest: DropletActionRequest = {
         type: 'password_reset'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -277,7 +276,7 @@ export class DropletActionService {
         size,
         type: 'password_reset'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -309,7 +308,7 @@ export class DropletActionService {
         image,
         type: 'rebuild'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -338,7 +337,7 @@ export class DropletActionService {
         name,
         type: 'rename'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -370,7 +369,7 @@ export class DropletActionService {
         kernel: kernelId,
         type: 'change_kernel'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -397,7 +396,7 @@ export class DropletActionService {
       const actionRequest: DropletActionRequest = {
         type: 'enable_ipv6'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -424,7 +423,7 @@ export class DropletActionService {
       const actionRequest: DropletActionRequest = {
         type: 'enable_private_networking'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -453,7 +452,7 @@ export class DropletActionService {
         name,
         type: 'snapshot'
       };
-      Axios.post(`${API_BASE_URL}/droplets/${dropletId}/actions`, actionRequest)
+      Axios.post(`/droplets/${dropletId}/actions`, actionRequest)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -483,7 +482,7 @@ export class DropletActionService {
     actionId: number
   ): Promise<Action> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/droplets/${dropletId}/actions/${actionId}`)
+      Axios.get(`/droplets/${dropletId}/actions/${actionId}`)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);

--- a/src/lib/services/droplet-service.ts
+++ b/src/lib/services/droplet-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Action } from '../models/action';
 import { Backup } from '../models/backup';
 import { Droplet, DropletRequest } from '../models/droplet';
@@ -38,7 +37,7 @@ export class DropletService {
    */
   public createNewDroplet(dropletRequest: DropletRequest): Promise<Droplet> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/droplets`, dropletRequest)
+      Axios.post(`/droplets`, dropletRequest)
         .then(response => {
           // Return actual droplet instead of wrapped droplet
           resolve(response.data.droplet);
@@ -81,7 +80,7 @@ export class DropletService {
     dropletsRequest: DropletRequest
   ): Promise<Droplet[]> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/droplets`, dropletsRequest)
+      Axios.post(`/droplets`, dropletsRequest)
         .then(response => {
           // Return actual droplets instead of wrapped droplets
           resolve(response.data.droplets);
@@ -105,7 +104,7 @@ export class DropletService {
    */
   public getExistingDroplet(dropletId: number): Promise<Droplet> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/droplets/${dropletId}`)
+      Axios.get(`/droplets/${dropletId}`)
         .then(response => {
           // Return actual droplet instead of wrapped droplet
           resolve(response.data.droplet);
@@ -129,7 +128,7 @@ export class DropletService {
    */
   public getAllDroplets(): Promise<Droplet[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/droplets`)
+      Axios.get(`/droplets`)
         .then(response => {
           // Return actual droplets instead of wrapped droplets
           resolve(response.data.droplets);
@@ -153,7 +152,7 @@ export class DropletService {
    */
   public getDropletsByTag(tag: string): Promise<Droplet[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/droplets?tag_name=${tag}`)
+      Axios.get(`/droplets?tag_name=${tag}`)
         .then(response => {
           // Return actual droplets instead of wrapped droplets
           resolve(response.data.droplets);
@@ -177,7 +176,7 @@ export class DropletService {
    */
   public getAvailableKernelsForDroplet(dropletId: number): Promise<Kernel[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/droplets/${dropletId}/kernels`)
+      Axios.get(`/droplets/${dropletId}/kernels`)
         .then(response => {
           // Return actual kernels instead of wrapped kernels
           resolve(response.data.kernels);
@@ -201,7 +200,7 @@ export class DropletService {
    */
   public getSnapshotsForDroplet(dropletId: number): Promise<Snapshot[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/droplets/${dropletId}/snapshots`)
+      Axios.get(`/droplets/${dropletId}/snapshots`)
         .then(response => {
           // Return actual snapshots instead of wrapped snapshots
           resolve(response.data.snapshots);
@@ -225,7 +224,7 @@ export class DropletService {
    */
   public getBackupsForDroplet(dropletId: number): Promise<Backup[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/droplets/${dropletId}/backups`)
+      Axios.get(`/droplets/${dropletId}/backups`)
         .then(response => {
           // Return actual backups instead of wrapped backups
           resolve(response.data.backups);
@@ -249,7 +248,7 @@ export class DropletService {
    */
   public getDropletActions(dropletId: number): Promise<Action[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/droplets/${dropletId}/actions`)
+      Axios.get(`/droplets/${dropletId}/actions`)
         .then(response => {
           // Return actual actions instead of wrapped actions
           resolve(response.data.actions);
@@ -273,7 +272,7 @@ export class DropletService {
    */
   public deleteDroplet(dropletId: number): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/droplets/${dropletId}`)
+      Axios.delete(`/droplets/${dropletId}`)
         .then(() => {
           resolve();
         })
@@ -296,7 +295,7 @@ export class DropletService {
    */
   public deleteDropletsByTag(tag: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/droplets?tag_name=${tag}`)
+      Axios.delete(`/droplets?tag_name=${tag}`)
         .then(() => {
           resolve();
         })
@@ -319,7 +318,7 @@ export class DropletService {
    */
   public getNeighborsForDroplet(dropletId: number): Promise<Droplet[]> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/droplets/${dropletId}/neighbors`)
+      Axios.delete(`/droplets/${dropletId}/neighbors`)
         .then(response => {
           // Return actual droplets instead of wrapped droplets
           resolve(response.data.droplets);
@@ -343,7 +342,7 @@ export class DropletService {
    */
   public getDropletNeighbors(): Promise<Droplet[][]> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/reports/droplet_neighbors`)
+      Axios.delete(`/reports/droplet_neighbors`)
         .then(response => {
           // Return actual neighbors instead of wrapped neighbors
           resolve(response.data.neighbors);

--- a/src/lib/services/firewall-service.ts
+++ b/src/lib/services/firewall-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import {
   Firewall,
   FirewallInboundRule,
@@ -65,7 +64,7 @@ export class FirewallService {
    */
   public createFirewall(firewall: Firewall): Promise<Firewall> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/firewalls`, firewall)
+      Axios.post(`/firewalls`, firewall)
         .then(response => {
           // Return actual firewall instead of wrapped firewall
           resolve(response.data.firewall);
@@ -89,7 +88,7 @@ export class FirewallService {
    */
   public getExistingFirewall(firewallId: string): Promise<Firewall> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/firewalls/${firewallId}`)
+      Axios.get(`/firewalls/${firewallId}`)
         .then(response => {
           // Return actual firewall instead of wrapped firewall
           resolve(response.data.firewall);
@@ -113,7 +112,7 @@ export class FirewallService {
    */
   public getAllFirewalls(): Promise<Firewall[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/firewalls`)
+      Axios.get(`/firewalls`)
         .then(response => {
           // Return actual firewalls instead of wrapped firewalls
           resolve(response.data.firewalls);
@@ -183,7 +182,7 @@ export class FirewallService {
    */
   public updateFirewall(firewall: Firewall): Promise<Firewall> {
     return new Promise((resolve, reject) => {
-      Axios.put(`${API_BASE_URL}/firewalls/${firewall.id}`, firewall)
+      Axios.put(`/firewalls/${firewall.id}`, firewall)
         .then(response => {
           // Return actual firewall instead of wrapped firewall
           resolve(response.data.firewall);
@@ -207,7 +206,7 @@ export class FirewallService {
    */
   public deleteFirewall(firewallId: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/firewalls/${firewallId}`)
+      Axios.delete(`/firewalls/${firewallId}`)
         .then(() => {
           resolve();
         })
@@ -240,7 +239,7 @@ export class FirewallService {
       const request = {
         droplet_ids: dropletIds
       };
-      Axios.post(`${API_BASE_URL}/firewalls/${firewallId}/droplets`, request)
+      Axios.post(`/firewalls/${firewallId}/droplets`, request)
         .then(() => {
           resolve();
         })
@@ -273,7 +272,7 @@ export class FirewallService {
       const request = {
         droplet_ids: dropletIds
       };
-      Axios.delete(`${API_BASE_URL}/firewalls/${firewallId}/droplets`, {
+      Axios.delete(`/firewalls/${firewallId}/droplets`, {
         data: request
       })
         .then(() => {
@@ -305,7 +304,7 @@ export class FirewallService {
       const request = {
         tags
       };
-      Axios.post(`${API_BASE_URL}/firewalls/${firewallId}/tags`, request)
+      Axios.post(`/firewalls/${firewallId}/tags`, request)
         .then(() => {
           resolve();
         })
@@ -338,7 +337,7 @@ export class FirewallService {
       const request = {
         tags
       };
-      Axios.delete(`${API_BASE_URL}/firewalls/${firewallId}/tags`, {
+      Axios.delete(`/firewalls/${firewallId}/tags`, {
         data: request
       })
         .then(() => {
@@ -393,7 +392,7 @@ export class FirewallService {
         inbound_rules: inboundRules,
         outbound_rules: outboundRules
       };
-      Axios.post(`${API_BASE_URL}/firewalls/${firewallId}/rules`, request)
+      Axios.post(`/firewalls/${firewallId}/rules`, request)
         .then(() => {
           resolve();
         })
@@ -446,7 +445,7 @@ export class FirewallService {
         inbound_rules: inboundRules,
         outbound_rules: outboundRules
       };
-      Axios.delete(`${API_BASE_URL}/firewalls/${firewallId}/rules`, {
+      Axios.delete(`/firewalls/${firewallId}/rules`, {
         data: request
       })
         .then(() => {

--- a/src/lib/services/floating-ip-actions-service.ts
+++ b/src/lib/services/floating-ip-actions-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Action } from '../models/action';
 
 export class FloatingIPActionService {
@@ -27,10 +26,7 @@ export class FloatingIPActionService {
         droplet_id: dropletId,
         type: 'assign'
       };
-      Axios.post(
-        `${API_BASE_URL}/floating_ips/${floatingIPAddress}/actions`,
-        request
-      )
+      Axios.post(`/floating_ips/${floatingIPAddress}/actions`, request)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -58,10 +54,7 @@ export class FloatingIPActionService {
       const request = {
         type: 'unassign'
       };
-      Axios.post(
-        `${API_BASE_URL}/floating_ips/${floatingIPAddress}/actions`,
-        request
-      )
+      Axios.post(`/floating_ips/${floatingIPAddress}/actions`, request)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -86,7 +79,7 @@ export class FloatingIPActionService {
    */
   public getAllFloatingIPActions(floatingIPAddress: string): Promise<Action[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/floating_ips/${floatingIPAddress}/actions`)
+      Axios.get(`/floating_ips/${floatingIPAddress}/actions`)
         .then(response => {
           // Return actual actions instead of wrapped actions
           resolve(response.data.actions);
@@ -114,9 +107,7 @@ export class FloatingIPActionService {
     actionId: string
   ): Promise<Action> {
     return new Promise((resolve, reject) => {
-      Axios.get(
-        `${API_BASE_URL}/floating_ips/${floatingIPAddress}/actions/${actionId}`
-      )
+      Axios.get(`/floating_ips/${floatingIPAddress}/actions/${actionId}`)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);

--- a/src/lib/services/floating-ip-service.ts
+++ b/src/lib/services/floating-ip-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { FloatingIP } from '../models/floating-ip';
 
 export class FloatingIPService {
@@ -19,7 +18,7 @@ export class FloatingIPService {
    */
   public getAllFloatingIPs(): Promise<FloatingIP> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/floating_ips`)
+      Axios.get(`/floating_ips`)
         .then(response => {
           // Return actual floating ips instead of wrapped floating ips
           resolve(response.data.floating_ips);
@@ -45,7 +44,7 @@ export class FloatingIPService {
   public createFloatingIPForDroplet(dropletId: string): Promise<FloatingIP> {
     return new Promise((resolve, reject) => {
       const request = { droplet_id: dropletId };
-      Axios.post(`${API_BASE_URL}/floating_ips`, request)
+      Axios.post(`/floating_ips`, request)
         .then(response => {
           // Return actual floating ip instead of wrapped floating ip
           resolve(response.data.floating_ip);
@@ -70,7 +69,7 @@ export class FloatingIPService {
    */
   public createFloatingIPForRegion(region: string): Promise<FloatingIP> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/floating_ips`, { region })
+      Axios.post(`/floating_ips`, { region })
         .then(response => {
           resolve(response.data.floating_ip);
         })
@@ -94,7 +93,7 @@ export class FloatingIPService {
    */
   public getExistingFloatingIP(floatingIPAddress: string): Promise<FloatingIP> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/floating_ips/${floatingIPAddress}`)
+      Axios.get(`/floating_ips/${floatingIPAddress}`)
         .then(response => {
           resolve(response.data.floating_ip);
         })
@@ -117,7 +116,7 @@ export class FloatingIPService {
    */
   public deleteFloatingIP(floatingIPAddress: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/floating_ips/${floatingIPAddress}`)
+      Axios.delete(`/floating_ips/${floatingIPAddress}`)
         .then(() => {
           resolve();
         })

--- a/src/lib/services/image-actions-service.ts
+++ b/src/lib/services/image-actions-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Action } from '../models/action';
 
 export class ImageActionService {
@@ -23,7 +22,7 @@ export class ImageActionService {
         region,
         type: 'transfer'
       };
-      Axios.post(`${API_BASE_URL}/images/${imageId}/actions`, request)
+      Axios.post(`/images/${imageId}/actions`, request)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -50,7 +49,7 @@ export class ImageActionService {
       const request = {
         type: 'convert'
       };
-      Axios.post(`${API_BASE_URL}/images/${imageId}/actions`, request)
+      Axios.post(`/images/${imageId}/actions`, request)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);
@@ -77,7 +76,7 @@ export class ImageActionService {
     actionId: number
   ): Promise<Action> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/images/${imageId}/actions/${actionId}`)
+      Axios.get(`/images/${imageId}/actions/${actionId}`)
         .then(response => {
           // Return actual action instead of wrapped action
           resolve(response.data.action);

--- a/src/lib/services/image-service.ts
+++ b/src/lib/services/image-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Action } from '../models/action';
 import { Image } from '../models/image';
 
@@ -20,7 +19,7 @@ export class ImageService {
    */
   public getAllImages(): Promise<Image[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/images`)
+      Axios.get(`/images`)
         .then(response => {
           // Return actual images instead of wrapped images
           resolve(response.data.images);
@@ -51,9 +50,7 @@ export class ImageService {
     return new Promise((resolve, reject) => {
       page = page ? page : 1;
       perPage = perPage ? perPage : 25;
-      Axios.get(
-        `${API_BASE_URL}/images?type=distribution&page=${page}&per_page=${perPage}`
-      )
+      Axios.get(`/images?type=distribution&page=${page}&per_page=${perPage}`)
         .then(response => {
           // Return actual images instead of wrapped images
           resolve(response.data.images);
@@ -84,9 +81,7 @@ export class ImageService {
     return new Promise((resolve, reject) => {
       page = page ? page : 1;
       perPage = perPage ? perPage : 25;
-      Axios.get(
-        `${API_BASE_URL}/images?type=application&page=${page}&per_page=${perPage}`
-      )
+      Axios.get(`/images?type=application&page=${page}&per_page=${perPage}`)
         .then(response => {
           // Return actual images instead of wrapped images
           resolve(response.data.images);
@@ -114,9 +109,7 @@ export class ImageService {
     return new Promise((resolve, reject) => {
       page = page ? page : 1;
       perPage = perPage ? perPage : 25;
-      Axios.get(
-        `${API_BASE_URL}/images?private=true&page=${page}&per_page=${perPage}`
-      )
+      Axios.get(`/images?private=true&page=${page}&per_page=${perPage}`)
         .then(response => {
           // Return actual images instead of wrapped images
           resolve(response.data.images);
@@ -140,7 +133,7 @@ export class ImageService {
    */
   public getImageActions(imageId: number): Promise<Action[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/images/${imageId}/actions`)
+      Axios.get(`/images/${imageId}/actions`)
         .then(response => {
           // Return actual actions instead of wrapped actions
           resolve(response.data.actions);
@@ -164,7 +157,7 @@ export class ImageService {
    */
   public getExistingImage(imageId: number): Promise<Image> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/images/${imageId}`)
+      Axios.get(`/images/${imageId}`)
         .then(response => {
           // Return actual image instead of wrapped image
           resolve(response.data.image);
@@ -188,7 +181,7 @@ export class ImageService {
    */
   public getExistingImageBySlug(imageSlug: string): Promise<Image> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/images/${imageSlug}`)
+      Axios.get(`/images/${imageSlug}`)
         .then(response => {
           // Return actual image instead of wrapped image
           resolve(response.data.image);
@@ -212,7 +205,7 @@ export class ImageService {
    */
   public updateImageName(imageId: number, name: string): Promise<Image> {
     return new Promise((resolve, reject) => {
-      Axios.put(`${API_BASE_URL}/images/${imageId}`, { name })
+      Axios.put(`/images/${imageId}`, { name })
         .then(response => {
           // Return actual image instead of wrapped image
           resolve(response.data.image);
@@ -236,7 +229,7 @@ export class ImageService {
    */
   public deleteImage(imageId: number): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/images/${imageId}`)
+      Axios.delete(`/images/${imageId}`)
         .then(() => {
           // Return actual image instead of wrapped image
           resolve();

--- a/src/lib/services/kubernetes-service.ts
+++ b/src/lib/services/kubernetes-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import {
   KubernetesCluster,
   KubernetesClusterRequest,
@@ -51,7 +50,7 @@ export class KubernetesService {
     cluster: KubernetesClusterRequest
   ): Promise<KubernetesCluster> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/kubernetes/clusters`, cluster)
+      Axios.post(`/kubernetes/clusters`, cluster)
         .then(response => {
           // Return actual cluster instead of wrapped cluster
           resolve(response.data.kubernetes_cluster);
@@ -75,7 +74,7 @@ export class KubernetesService {
    */
   public getCluster(clusterId: string): Promise<KubernetesCluster> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/kubernetes/clusters/${clusterId}`)
+      Axios.get(`/kubernetes/clusters/${clusterId}`)
         .then(response => {
           // Return actual cluster instead of wrapped cluster
           resolve(response.data.kubernetes_cluster);
@@ -99,7 +98,7 @@ export class KubernetesService {
    */
   public getAllClusters(): Promise<KubernetesCluster[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/kubernetes/clusters`)
+      Axios.get(`/kubernetes/clusters`)
         .then(response => {
           // Return actual cluster instead of wrapped cluster
           resolve(response.data.kubernetes_clusters);
@@ -133,7 +132,7 @@ export class KubernetesService {
     cluster: KubernetesCluster
   ): Promise<KubernetesCluster> {
     return new Promise((resolve, reject) => {
-      Axios.put(`${API_BASE_URL}/kubernetes/clusters/${clusterId}`, cluster)
+      Axios.put(`/kubernetes/clusters/${clusterId}`, cluster)
         .then(response => {
           // Return actual cluster instead of wrapped cluster
           resolve(response.data.kubernetes_cluster);
@@ -159,7 +158,7 @@ export class KubernetesService {
     clusterId: string
   ): Promise<KubernetesVersion[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/kubernetes/clusters/${clusterId}/upgrades`)
+      Axios.get(`/kubernetes/clusters/${clusterId}/upgrades`)
         .then(response => {
           // Return actual versions instead of wrapped versions
           resolve(response.data.available_upgrade_versions);
@@ -186,7 +185,7 @@ export class KubernetesService {
     version: string
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/kubernetes/clusters/${clusterId}/upgrade`, {
+      Axios.post(`/kubernetes/clusters/${clusterId}/upgrade`, {
         version
       })
         .then(() => {
@@ -211,7 +210,7 @@ export class KubernetesService {
    */
   public deleteCluster(clusterId: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/kubernetes/clusters/${clusterId}`)
+      Axios.delete(`/kubernetes/clusters/${clusterId}`)
         .then(() => {
           resolve();
         })
@@ -234,7 +233,7 @@ export class KubernetesService {
    */
   public getClusterKubeconfig(clusterId: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/kubernetes/clusters/${clusterId}/kubeconfig`)
+      Axios.get(`/kubernetes/clusters/${clusterId}/kubeconfig`)
         .then(response => {
           resolve(response.data);
         })
@@ -260,9 +259,7 @@ export class KubernetesService {
     poolId: string
   ): Promise<KubernetesWorkerNodePool> {
     return new Promise((resolve, reject) => {
-      Axios.get(
-        `${API_BASE_URL}/kubernetes/clusters/${clusterId}/node_pools/${poolId}`
-      )
+      Axios.get(`/kubernetes/clusters/${clusterId}/node_pools/${poolId}`)
         .then(response => {
           resolve(response.data.node_pool);
         })
@@ -287,7 +284,7 @@ export class KubernetesService {
     clusterId: string
   ): Promise<KubernetesWorkerNodePool[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/kubernetes/clusters/${clusterId}/node_pools`)
+      Axios.get(`/kubernetes/clusters/${clusterId}/node_pools`)
         .then(response => {
           resolve(response.data.node_pools);
         })
@@ -321,10 +318,7 @@ export class KubernetesService {
     nodePool: KubernetesWorkerNodePool
   ): Promise<KubernetesWorkerNodePool> {
     return new Promise((resolve, reject) => {
-      Axios.post(
-        `${API_BASE_URL}/kubernetes/clusters/${clusterId}/node_pools`,
-        nodePool
-      )
+      Axios.post(`/kubernetes/clusters/${clusterId}/node_pools`, nodePool)
         .then(response => {
           resolve(response.data.node_pool);
         })
@@ -359,7 +353,7 @@ export class KubernetesService {
   ): Promise<KubernetesWorkerNodePool> {
     return new Promise((resolve, reject) => {
       Axios.post(
-        `${API_BASE_URL}/kubernetes/clusters/${clusterId}/node_pools/${nodePoolId}`,
+        `/kubernetes/clusters/${clusterId}/node_pools/${nodePoolId}`,
         nodePool
       )
         .then(response => {
@@ -387,9 +381,7 @@ export class KubernetesService {
     nodePoolId: string
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(
-        `${API_BASE_URL}/kubernetes/clusters/${clusterId}/node_pools/${nodePoolId}`
-      )
+      Axios.delete(`/kubernetes/clusters/${clusterId}/node_pools/${nodePoolId}`)
         .then(() => {
           resolve();
         })
@@ -418,7 +410,7 @@ export class KubernetesService {
     replace?: boolean
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      const url = `${API_BASE_URL}/kubernetes/clusters/${clusterId}/node_pools/${nodePoolId}?skip_drain=${
+      const url = `/kubernetes/clusters/${clusterId}/node_pools/${nodePoolId}?skip_drain=${
         skipDrain ? 1 : 0
       }&replace=${replace ? 1 : 0}`;
       Axios.delete(url)
@@ -444,7 +436,7 @@ export class KubernetesService {
    */
   public getKubernetesOptions(): Promise<KubernetesOptions> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/kubernetes/options`)
+      Axios.get(`/kubernetes/options`)
         .then(response => {
           resolve(response.data.options);
         })

--- a/src/lib/services/load-balancer-service.ts
+++ b/src/lib/services/load-balancer-service.ts
@@ -1,5 +1,5 @@
 import Axios from 'axios';
-import { API_BASE_URL } from '../conf/environment';
+
 import {
   ForwardingRule,
   HealthCheck,
@@ -76,7 +76,7 @@ export class LoadBalancerService {
           throw new Error('Required fields missing from Health Check Object');
         }
       }
-      Axios.post(`${API_BASE_URL}/load_balancers`, loadBalancer)
+      Axios.post(`/load_balancers`, loadBalancer)
         .then(response => {
           // Return actual load_balancer instead of wrapped load_balancer
           resolve(response.data.load_balancer);
@@ -100,7 +100,7 @@ export class LoadBalancerService {
    */
   public getExistingLoadBalancer(id: string): Promise<LoadBalancer> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/load_balancers/${id}`)
+      Axios.get(`/load_balancers/${id}`)
         .then(response => {
           // Return actual load_balancer instead of wrapped load_balancer
           resolve(response.data.load_balancer);
@@ -124,7 +124,7 @@ export class LoadBalancerService {
    */
   public getAllLoadBalancers(): Promise<LoadBalancer[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/load_balancers`)
+      Axios.get(`/load_balancers`)
         .then(response => {
           // Return actual load_balancers instead of wrapped load_balancers
           resolve(response.data.load_balancers);
@@ -203,10 +203,7 @@ export class LoadBalancerService {
           throw new Error('Required fields missing from Health Check Object');
         }
       }
-      Axios.put(
-        `${API_BASE_URL}/load_balancers/${loadBalancer.id}`,
-        loadBalancer
-      )
+      Axios.put(`/load_balancers/${loadBalancer.id}`, loadBalancer)
         .then(response => {
           // Return actual load_balancer instead of wrapped load_balancer
           resolve(response.data.load_balancer);
@@ -230,7 +227,7 @@ export class LoadBalancerService {
    */
   public deleteLoadBalancer(id: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/load_balancers/${id}`)
+      Axios.delete(`/load_balancers/${id}`)
         .then(() => {
           resolve();
         })
@@ -261,7 +258,7 @@ export class LoadBalancerService {
     dropletIds: number[]
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/load_balancers/${id}`, {
+      Axios.post(`/load_balancers/${id}`, {
         droplet_ids: dropletIds
       })
         .then(() => {
@@ -294,7 +291,7 @@ export class LoadBalancerService {
     dropletIds: number[]
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/load_balancers/${id}`, {
+      Axios.delete(`/load_balancers/${id}`, {
         data: { droplet_ids: dropletIds }
       })
         .then(() => {
@@ -338,7 +335,7 @@ export class LoadBalancerService {
           );
         }
       });
-      Axios.post(`${API_BASE_URL}/load_balancers/${id}/forwarding_rules`, {
+      Axios.post(`/load_balancers/${id}/forwarding_rules`, {
         forwarding_rules: rules
       })
         .then(() => {
@@ -382,7 +379,7 @@ export class LoadBalancerService {
           );
         }
       });
-      Axios.delete(`${API_BASE_URL}/load_balancers/${id}/forwarding_rules`, {
+      Axios.delete(`/load_balancers/${id}/forwarding_rules`, {
         data: { forwarding_rules: rules }
       })
         .then(() => {

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -1,5 +1,5 @@
 import Axios from 'axios';
-import { API_BASE_URL } from '../conf/environment';
+
 import { Project, ProjectPurpose, ProjectResource } from '../models/project';
 
 export class ProjectService {
@@ -18,7 +18,7 @@ export class ProjectService {
    */
   public getAllProjects(): Promise<Project[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/projects`)
+      Axios.get(`/projects`)
         .then(response => {
           // Return actual projects instead of wrapped projects
           resolve(response.data.projects);
@@ -42,7 +42,7 @@ export class ProjectService {
    */
   public getExistingProject(id: string): Promise<Project> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/projects/${id}`)
+      Axios.get(`/projects/${id}`)
         .then(response => {
           // Return actual project instead of wrapped project
           resolve(response.data.project);
@@ -95,7 +95,7 @@ export class ProjectService {
           'Project purpose is not one of the allowed values. Use a proper purpose value.'
         );
       }
-      Axios.post(`${API_BASE_URL}/projects`, project)
+      Axios.post(`/projects`, project)
         .then(response => {
           // Return actual project instead of wrapped project
           resolve(response.data.project);
@@ -134,7 +134,7 @@ export class ProjectService {
           'Project purpose is not one of the allowed values. Use a proper purpose value.'
         );
       }
-      Axios.put(`${API_BASE_URL}/projects/${id}`, project)
+      Axios.put(`/projects/${id}`, project)
         .then(response => {
           // Return actual project instead of wrapped project
           resolve(response.data.project);
@@ -180,7 +180,7 @@ export class ProjectService {
    */
   public getProjectResources(id: string): Promise<ProjectResource[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/projects/${id}/resources`)
+      Axios.get(`/projects/${id}/resources`)
         .then(response => {
           // Return actual resources instead of wrapped resources
           resolve(response.data.resources);
@@ -230,7 +230,7 @@ export class ProjectService {
     resources: string[]
   ): Promise<ProjectResource[]> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/projects/${id}/resources`, { resources })
+      Axios.post(`/projects/${id}/resources`, { resources })
         .then(response => {
           // Return actual resources instead of wrapped resources
           resolve(response.data.resources);

--- a/src/lib/services/region-service.ts
+++ b/src/lib/services/region-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Region } from '../models/region';
 
 export class RegionService {
@@ -19,7 +18,7 @@ export class RegionService {
    */
   public getAllRegions(): Promise<Region[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/regions`)
+      Axios.get(`/regions`)
         .then(response => {
           // Return actual regions instead of wrapped regions
           resolve(response.data.regions);

--- a/src/lib/services/size-service.ts
+++ b/src/lib/services/size-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Size } from '../models/size';
 
 export class SizeService {
@@ -19,7 +18,7 @@ export class SizeService {
    */
   public getAllSizes(): Promise<Size[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/sizes`)
+      Axios.get(`/sizes`)
         .then(response => {
           // Return actual sizes instead of wrapped sizes
           resolve(response.data.sizes);

--- a/src/lib/services/snapshot-service.ts
+++ b/src/lib/services/snapshot-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Snapshot } from '../models/snapshot';
 
 export type SnapshotType = 'all' | 'droplet' | 'volume';
@@ -27,7 +26,7 @@ export class SnapshotService {
    */
   public getSnapshots(resourceType?: SnapshotType): Promise<Snapshot[]> {
     return new Promise((resolve, reject) => {
-      let url = `${API_BASE_URL}/snapshots`;
+      let url = `/snapshots`;
       if (resourceType && resourceType !== 'all') {
         url += `?resource_type=${resourceType}`;
       }
@@ -55,7 +54,7 @@ export class SnapshotService {
    */
   public getSnapshotById(snapshotId: string): Promise<Snapshot> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/snapshots/${snapshotId}`)
+      Axios.get(`/snapshots/${snapshotId}`)
         .then(response => {
           // Return actual snapshot instead of wrapped snapshot
           resolve(response.data.snapshot);
@@ -79,7 +78,7 @@ export class SnapshotService {
    */
   public deleteSnapshot(snapshotId: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/snapshots/${snapshotId}`)
+      Axios.delete(`/snapshots/${snapshotId}`)
         .then(() => {
           // Return actual snapshot instead of wrapped snapshot
           resolve();

--- a/src/lib/services/ssh-service.ts
+++ b/src/lib/services/ssh-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { SshKey } from '../models/ssh-key';
 
 export class SshService {
@@ -19,7 +18,7 @@ export class SshService {
    */
   public getAllKeys(): Promise<SshKey[]> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/account/keys`)
+      Axios.get(`/account/keys`)
         .then(response => {
           // Return actual ssh keys instead of wrapped ssh keys
           resolve(response.data.ssh_keys);
@@ -47,7 +46,7 @@ export class SshService {
    */
   public createNewKey(key: SshKey): Promise<SshKey> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/account/keys`, key)
+      Axios.post(`/account/keys`, key)
         .then(response => {
           // Return actual ssh key instead of wrapped ssh key
           resolve(response.data.ssh_key);
@@ -71,7 +70,7 @@ export class SshService {
    */
   public getExistingKey(idOrFingerprint: string): Promise<SshKey> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/account/keys/${idOrFingerprint}`)
+      Axios.get(`/account/keys/${idOrFingerprint}`)
         .then(response => {
           // Return actual ssh key instead of wrapped ssh key
           resolve(response.data.ssh_key);
@@ -98,7 +97,7 @@ export class SshService {
    */
   public updateKey(idOrFingerprint: string, key: SshKey): Promise<SshKey> {
     return new Promise((resolve, reject) => {
-      Axios.put(`${API_BASE_URL}/account/keys/${idOrFingerprint}`, key)
+      Axios.put(`/account/keys/${idOrFingerprint}`, key)
         .then(response => {
           // Return actual ssh key instead of wrapped ssh key
           resolve(response.data.ssh_key);
@@ -122,7 +121,7 @@ export class SshService {
    */
   public deleteKey(idOrFingerprint: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/account/keys/${idOrFingerprint}`)
+      Axios.delete(`/account/keys/${idOrFingerprint}`)
         .then(() => {
           // Return actual ssh key instead of wrapped ssh key
           resolve();

--- a/src/lib/services/tag-service.ts
+++ b/src/lib/services/tag-service.ts
@@ -1,6 +1,5 @@
 import Axios from 'axios';
 
-import { API_BASE_URL } from '../conf/environment';
 import { Tag } from '../models/tag';
 
 export class TagService {
@@ -19,7 +18,7 @@ export class TagService {
    */
   public createTag(name: string): Promise<Tag> {
     return new Promise((resolve, reject) => {
-      Axios.post(`${API_BASE_URL}/tags`, { name })
+      Axios.post(`/tags`, { name })
         .then(response => {
           // Return actual tag instead of wrapped tag
           resolve(response.data.tag);
@@ -43,7 +42,7 @@ export class TagService {
    */
   public getTags(): Promise<Tag> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/tags`)
+      Axios.get(`/tags`)
         .then(response => {
           // Return actual tags instead of wrapped tags
           resolve(response.data.tags);
@@ -67,7 +66,7 @@ export class TagService {
    */
   public getTagByName(tagName: string): Promise<Tag> {
     return new Promise((resolve, reject) => {
-      Axios.get(`${API_BASE_URL}/tags/${tagName}`)
+      Axios.get(`/tags/${tagName}`)
         .then(response => {
           // Return actual tag instead of wrapped tag
           resolve(response.data.tag);
@@ -102,7 +101,7 @@ export class TagService {
           resource_type: 'droplet'
         };
       });
-      Axios.post(`${API_BASE_URL}/tags/${tagName}/resources`, { resources })
+      Axios.post(`/tags/${tagName}/resources`, { resources })
         .then(() => {
           resolve();
         })
@@ -139,7 +138,7 @@ export class TagService {
           resource_type: 'droplet'
         };
       });
-      Axios.delete(`${API_BASE_URL}/tags/${tagName}/resources`, {
+      Axios.delete(`/tags/${tagName}/resources`, {
         data: { resources }
       })
         .then(() => {
@@ -164,7 +163,7 @@ export class TagService {
    */
   public deleteTag(tagName: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      Axios.delete(`${API_BASE_URL}/tags/${tagName}`)
+      Axios.delete(`/tags/${tagName}`)
         .then(() => {
           resolve();
         })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This change introduces feature that allows users to set a different API base URL in the constructor. Instead of using the `API_BASE_URL` in each service, this change allows users to optionally provide their own URL, falling back to the `API_BASE_URL` if no URL is provided.

**What is the current behavior?**

Currently, the API's URL is hardcoded to `https://api.digitalocean.com`. I've been using this project today on an internal hackathon project (I work at DO), and would like to set the URL so I can use this against an internal staging environment.

**What is the new behavior?**

As mentioned, this makes the API URL configurable in the constructor. It does this by using Axios's `baseURL` config value, which is now set in the constructor, rather than using the `API_BASE_URL` variable.

---

If this isn't the right approach, I'm happy to discuss other ways to add this functionality. Thanks for the great project @johnbwoodruff!
