### PR TITLE
Fix correct API for deleting node from nodePool

### DIFF
--- a/src/lib/services/kubernetes-service.ts
+++ b/src/lib/services/kubernetes-service.ts
@@ -413,19 +413,20 @@ export class KubernetesService {
    * import { DigitalOcean } from 'digitalocean-js';
    *
    * const client = new DigitalOcean('your-api-key');
-   * await client.kubernetes.deleteNodeFromNodePoolForCluster('cluster-id', 'pool-id', false, false);
+   * await client.kubernetes.deleteNodeFromNodePoolForCluster('cluster-id', 'pool-id', 'node-id', false, false);
    * ```
    */
   public deleteNodeFromNodePoolForCluster(
     clusterId: string,
     nodePoolId: string,
+    nodeId: string,
     skipDrain?: boolean,
     replace?: boolean
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      const url = `/kubernetes/clusters/${clusterId}/node_pools/${nodePoolId}?skip_drain=${
+      const url = `/kubernetes/clusters/${clusterId}/node_pools/${nodePoolId}/nodes/${nodeId}?skip_drain=${
         skipDrain ? 1 : 0
-      }&replace=${replace ? 1 : 0}`;
+        }&replace=${replace ? 1 : 0}`;
       axios
         .delete(url)
         .then(() => {


### PR DESCRIPTION
Incorrect API for deleteNodeFromNodePoolForCluster

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
Current API endpoint is incorrect. More info can be found at [API Docs](https://developers.digitalocean.com/documentation/v2/#delete-a-node-in-a-kubernetes-cluster)


* **What is the new behavior (if this is a feature change)?**
Corrected the function and comment according to the docs