### PR TITLE
Fix typo in KubernetesCluster interface.

### DIFF
--- a/src/lib/models/kubernetes-cluster.ts
+++ b/src/lib/models/kubernetes-cluster.ts
@@ -6,7 +6,7 @@ export interface KubernetesCluster {
   version: string;
   auto_upgrade: boolean;
   ipv4: string;
-  custer_subnet: string;
+  cluster_subnet: string;
   service_subnet: string;
   tags: string[];
   maintenance_policy: KubernetesClusterMaintenancePolicy;


### PR DESCRIPTION
Rename "custer_subnet" to "cluster_subnet".

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Renames a field in the KubernetesCluster interface.

* **What is the current behavior?** (You can also link to an open issue here)
The field has the wrong name.

* **What is the new behavior (if this is a feature change)?**
The field has the right name.

* **Other information**:
That's it.