### PR TITLE
getTags() return type corrected

### DIFF
--- a/packages/digitalocean-js/src/lib/services/tag/tag.service.ts
+++ b/packages/digitalocean-js/src/lib/services/tag/tag.service.ts
@@ -29,7 +29,7 @@ export class TagService {
    * const tags = await client.tags.getTags();
    * ```
    */
-  public getTags(): Promise<Tag> {
+  public getTags(): Promise<Tag[]> {
     return instance.get(`/tags`).then(response => response.data.tags);
   }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
getTags() function actually returns array of tags, but the type is only `Tag`


* **What is the new behavior (if this is a feature change)?**
Changed return type of getTags()  function to `Tag[]`


* **Other information**:
