### PR TITLE
getAllImages wasn't fetching all images

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "digitalocean-js-source",
-  "version": "2.0.3",
+  "name": "@rhythmbhiwani/digitalocean-js-source",
+  "version": "2.0.4",
   "description": "JavaScript library for the DigitalOcean API",
   "private": false,
   "repository": "https://github.com/johnbwoodruff/digitalocean-js",

--- a/packages/digitalocean-js/package.json
+++ b/packages/digitalocean-js/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "digitalocean-js",
-  "version": "2.0.3",
+  "name": "@rhythmbhiwani/digitalocean-js",
+  "version": "2.0.4",
   "description": "JavaScript library for the DigitalOcean API",
   "private": false,
   "repository": "https://github.com/johnbwoodruff/digitalocean-js",

--- a/packages/digitalocean-js/src/lib/models/image.ts
+++ b/packages/digitalocean-js/src/lib/models/image.ts
@@ -9,6 +9,7 @@ export interface Image {
   min_disk_size: number;
   size_gigabytes: number;
   created_at: string;
+  description: string;
 }
 
 export interface ImageActionRequest {

--- a/packages/digitalocean-js/src/lib/models/size.ts
+++ b/packages/digitalocean-js/src/lib/models/size.ts
@@ -8,4 +8,5 @@ export interface Size {
   vcpus: number;
   disk: number;
   regions: string[];
+  description: string;
 }

--- a/packages/digitalocean-js/src/lib/services/image/image.service.ts
+++ b/packages/digitalocean-js/src/lib/services/image/image.service.ts
@@ -1,6 +1,6 @@
-import { Action, Image } from '../../models';
+import { Action, Image } from "../../models";
 
-import { instance } from '../../axios-instance';
+import { instance } from "../../axios-instance";
 
 export class ImageService {
   /**
@@ -15,7 +15,9 @@ export class ImageService {
    * ```
    */
   public getAllImages(): Promise<Image[]> {
-    return instance.get(`/images`).then(response => response.data.images);
+    return instance
+      .get(`/images`, { params: { per_page: 200 } })
+      .then((response) => response.data.images);
   }
 
   /**
@@ -39,9 +41,9 @@ export class ImageService {
     perPage = perPage ? perPage : 25;
     return instance
       .get(`/images`, {
-        params: { type: 'distribution', page, per_page: perPage }
+        params: { type: "distribution", page, per_page: perPage },
       })
-      .then(response => response.data.images);
+      .then((response) => response.data.images);
   }
 
   /**
@@ -65,9 +67,9 @@ export class ImageService {
     perPage = perPage ? perPage : 25;
     return instance
       .get(`/images`, {
-        params: { type: 'application', page, per_page: perPage }
+        params: { type: "application", page, per_page: perPage },
       })
-      .then(response => response.data.images);
+      .then((response) => response.data.images);
   }
 
   /**
@@ -88,9 +90,9 @@ export class ImageService {
     perPage = perPage ? perPage : 25;
     return instance
       .get(`/images`, {
-        params: { private: true, page, per_page: perPage }
+        params: { private: true, page, per_page: perPage },
       })
-      .then(response => response.data.images);
+      .then((response) => response.data.images);
   }
 
   /**
@@ -107,7 +109,7 @@ export class ImageService {
   public getImageActions(imageId: number): Promise<Action[]> {
     return instance
       .get(`/images/${imageId}/actions`)
-      .then(response => response.data.actions);
+      .then((response) => response.data.actions);
   }
 
   /**
@@ -124,7 +126,7 @@ export class ImageService {
   public getExistingImage(imageId: number): Promise<Image> {
     return instance
       .get(`/images/${imageId}`)
-      .then(response => response.data.image);
+      .then((response) => response.data.image);
   }
 
   /**
@@ -141,7 +143,7 @@ export class ImageService {
   public getExistingImageBySlug(imageSlug: string): Promise<Image> {
     return instance
       .get(`/images/${imageSlug}`)
-      .then(response => response.data.image);
+      .then((response) => response.data.image);
   }
 
   /**
@@ -158,7 +160,7 @@ export class ImageService {
   public updateImageName(imageId: number, name: string): Promise<Image> {
     return instance
       .put(`/images/${imageId}`, { name })
-      .then(response => response.data.image);
+      .then((response) => response.data.image);
   }
 
   /**

--- a/packages/digitalocean-js/src/lib/services/image/image.service.ts
+++ b/packages/digitalocean-js/src/lib/services/image/image.service.ts
@@ -16,7 +16,7 @@ export class ImageService {
    */
   public getAllImages(): Promise<Image[]> {
     return instance
-      .get(`/images`, { params: { per_page: 200 } })
+      .get(`/images`, { params: { per_page: 500 } })
       .then((response) => response.data.images);
   }
 

--- a/packages/digitalocean-js/src/lib/services/size/size.service.ts
+++ b/packages/digitalocean-js/src/lib/services/size/size.service.ts
@@ -1,6 +1,6 @@
-import { Size } from '../../models';
+import { Size } from "../../models";
 
-import { instance } from '../../axios-instance';
+import { instance } from "../../axios-instance";
 
 export class SizeService {
   /**
@@ -15,6 +15,8 @@ export class SizeService {
    * ```
    */
   public getAllSizes(): Promise<Size[]> {
-    return instance.get(`/sizes`).then(response => response.data.sizes);
+    return instance
+      .get(`/sizes`, { params: { per_page: 500 } })
+      .then((response) => response.data.sizes);
   }
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
getAllImages only fetches the first 20 images as no params are passed in the api


* **What is the new behavior (if this is a feature change)?**
Added the param `per_page` with value `500 `  so that it fetches almost all the images at once, although as of now there are only `195` images present


* **Other information**:
Also Added some missing type data in models